### PR TITLE
Support 64-bit unsigned ints in the JavaScript version of libsbp.

### DIFF
--- a/c/include/libsbp/tracking.h
+++ b/c/include/libsbp/tracking.h
@@ -25,9 +25,48 @@
 
 #include "common.h"
 #include "gnss_signal.h"
+#include "observation.h"
 
 
-/** Satellite tracking channel state
+/** Detailed signal tracking channel states
+ *
+ * The tracking message returns a set tracking channel parameters for a
+ * single tracking channel useful for debugging issues.
+ */
+#define SBP_MSG_TRACKING_STATE_DETAILED 0x0011
+typedef struct __attribute__((packed)) {
+  u64 recv_time;       /**< Receiver clock time. [ns] */
+  obs_gps_time_t tot;             /**< Time of transmission of signal from satellite. */
+  u32 P;               /**< Pseudorange observation. [2 cm] */
+  u16 P_std;           /**< Pseudorange observation standard deviation. [2 cm] */
+  carrier_phase_t L;               /**< Carrier phase observation with typical sign convention. Only valid
+when PLL pessimistic lock is achieved.
+ [cycles] */
+  u8 cn0;             /**< Carrier-to-Noise density [dB Hz * 4] */
+  u16 lock;            /**< Lock indicator. This value changes whenever a satellite
+signal has lost and regained lock, indicating that the
+carrier phase ambiguity may have changed.
+ */
+  sbp_gnss_signal_t sid;             /**< GNSS signal identifier. */
+  s32 doppler;         /**< Carrier Doppler frequency. [Hz * 10] */
+  u16 doppler_std;     /**< Carrier Doppler frequency standard deviation. [Hz * 10] */
+  u32 uptime;          /**< Number of seconds of continuous tracking. Specifies how much time
+signal is in continuous track.
+ [s] */
+  u16 clock_offset;    /**< TCXO clock offset. [ppb * 10] */
+  u16 clock_drift;     /**< TCXO clock drift. [(ppb * 10) / s] */
+  u16 corr_spacing;    /**< Early-Prompt (EP) and Prompt-Late (PL) correlators spacing. [ns] */
+  u8 acceleration;    /**< Acceleration. Valid only when acceleration valid flag is set. [g * 10] */
+  u8 sync_flags;      /**< Synchronization status flags. */
+  u8 tow_flags;       /**< TOW status flags. */
+  u8 track_flags;     /**< Tracking loop status flags. */
+  u8 nav_flags;       /**< Navigation data status flags. */
+  u8 pset_flags;      /**< Parameters sets flags. */
+  u8 misc_flags;      /**< Miscellaneous flags. */
+} msg_tracking_state_detailed_t;
+
+
+/** Signal tracking channel state
  *
  * Tracking channel state for a specific satellite signal and
  * measured signal power.
@@ -39,15 +78,15 @@ typedef struct __attribute__((packed)) {
 } tracking_channel_state_t;
 
 
-/** Satellite tracking channel states
+/** Signal tracking channel states
  *
  * The tracking message returns a variable-length array of tracking
  * channel states. It reports status and carrier-to-noise density
  * measurements for all tracked satellites.
  */
-#define SBP_MSG_TRACKING_STATE       0x0013
+#define SBP_MSG_TRACKING_STATE          0x0013
 typedef struct __attribute__((packed)) {
-  tracking_channel_state_t states[0]; /**< Satellite tracking channel state */
+  tracking_channel_state_t states[0]; /**< Signal tracking channel state */
 } msg_tracking_state_t;
 
 
@@ -66,7 +105,7 @@ typedef struct __attribute__((packed)) {
  * When enabled, a tracking channel can output the correlations at each
  * update interval.
  */
-#define SBP_MSG_TRACKING_IQ          0x001C
+#define SBP_MSG_TRACKING_IQ             0x001C
 typedef struct __attribute__((packed)) {
   u8 channel;    /**< Tracking channel of origin */
   sbp_gnss_signal_t sid;        /**< GNSS signal identifier */
@@ -89,7 +128,7 @@ typedef struct __attribute__((packed)) {
  *
 * Deprecated.
  */
-#define SBP_MSG_TRACKING_STATE_DEP_A 0x0016
+#define SBP_MSG_TRACKING_STATE_DEP_A    0x0016
 typedef struct __attribute__((packed)) {
   tracking_channel_state_dep_a_t states[0]; /**< Satellite tracking channel state */
 } msg_tracking_state_dep_a_t;

--- a/generator/sbpg/targets/javascript.py
+++ b/generator/sbpg/targets/javascript.py
@@ -41,11 +41,11 @@ WRITE_BUFFER_CODE = {
   'u8': 'writeUInt8',
   'u16': 'writeUInt16LE',
   'u32': 'writeUInt32LE',
-  'u64': 'writeUIntLE', # only supports up to 48 bits of accuracy
+  'u64': 'writeUInt64LE', # only supports up to 48 bits of accuracy
   's8': 'writeInt8',
   's16': 'writeInt16LE',
   's32': 'writeInt32LE',
-  's64': 'writeIntLE', # only supports up to 48 bits of accuracy
+  's64': 'writeInt64LE', # only supports up to 48 bits of accuracy
   'float': 'writeFloatLE',
   'double': 'writeDoubleLE',
 }
@@ -96,6 +96,19 @@ def buffer_size(type_id, type_map=BUFFER_SIZE_MAP):
     return "this.fields.%s.length" % type_id
   else:
     return "this.fields.%s.length" % type_id.identifier
+
+def array_fill_size(f):
+  if builtin_type(f.options['fill'].value):
+    return buffer_size(f.options['fill'].value)
+  else:
+    return buffer_size(f.type_id)
+
+def array_length(f):
+  if 'size' in f.options:
+    return f.options.get('size').value
+  if 'size_fn' in f.options:
+    return "'%s'" % f.options.get('size_fn').value
+  return 'null'
 
 def jsdoc_format(type_id, jsdoc=JSDOC_CODE):
   """
@@ -151,11 +164,17 @@ def star_wordwrap(s):
 def star_wordwrap_indent(s):
   return "\n *   ".join(textwrap.wrap(' '.join(s.split('\n')), 80))
 
+def islist(x):
+  return isinstance(x, list)
+
 JENV.tests['builtinType'] = builtin_type
+JENV.tests['list'] = islist
 
 JENV.filters['js_classnameify'] = js_classnameify
 JENV.filters['writeBuffer'] = write_buffer
 JENV.filters['bufferSize'] = buffer_size
+JENV.filters['arrayFillSize'] = array_fill_size
+JENV.filters['arrayLength'] = array_length
 JENV.filters['construct_js'] = construct_format
 JENV.filters['jsdoc'] = jsdoc_format
 JENV.filters['starWordWrap'] = star_wordwrap
@@ -171,7 +190,7 @@ def render_source(output_dir, package_spec, jenv=JENV):
   destination_filename = "%s/%s.js" % (directory, name)
   py_template = jenv.get_template(TEMPLATE_NAME)
   module_path = ".".join(package_spec.identifier.split(".")[1:-1])
-  includeMap = {'gnss_signal':'GnssSignal'}
+  includeMap = {'gnss_signal':'GnssSignal', 'observation': ['ObsGPSTime', 'CarrierPhase'] }
   includes = [".".join(i.split(".")[:-1]) for i in package_spec.includes]
   includes = [(i, includeMap.get(i)) for i in includes if i != "types"]
   with open(destination_filename, 'w') as f:

--- a/generator/sbpg/targets/resources/sbp_js.js.j2
+++ b/generator/sbpg/targets/resources/sbp_js.js.j2
@@ -19,9 +19,17 @@
 ***********************/
 
 var SBP = require('./sbp');
-var Parser = require('binary-parser').Parser;
+var Parser = require('./parser');
+var Int64 = require('node-int64');
+var UInt64 = require('cuint').UINT64;
 ((*- for (file, ident) in include *))
+((*- if ident is list *))
+((*- for ident2 in ident *))
+var (((ident2))) = require("./(((file)))").(((ident2)));
+((*- endfor *))
+((*- else *))
 var (((ident))) = require("./(((file)))").(((ident)));
+((*- endif *))
 ((*- endfor *))
 
 ((*- for m in msgs *))
@@ -60,11 +68,11 @@ var ((( m.identifier | js_classnameify ))) = function (sbp, fields) {
 ((*- if f.type_id is builtinType *))
 ((( m.identifier | js_classnameify ))).prototype.fieldSpec.push(['(((f.identifier)))', '(((f.type_id | writeBuffer)))', (((f.type_id | bufferSize)))]);
 ((*- elif f.type_id == 'array' and f.options['fill'].value is builtinType *))
-((( m.identifier | js_classnameify ))).prototype.fieldSpec.push(['(((f.identifier)))', 'array', '(((f.options['fill'].value | writeBuffer)))', function () { return (((f.options['fill'].value | bufferSize))); }]);
+((( m.identifier | js_classnameify ))).prototype.fieldSpec.push(['(((f.identifier)))', 'array', '(((f.options['fill'].value | writeBuffer)))', function () { return (((f | arrayFillSize))); }, ((( f | arrayLength )))]);
 ((*- elif f.type_id == 'array' *))
-((( m.identifier | js_classnameify ))).prototype.fieldSpec.push(['(((f.identifier)))', 'array', ((( f.options['fill'].value ))).prototype.fieldSpec, function () { return (((f.type_id | bufferSize))); }]);
+((( m.identifier | js_classnameify ))).prototype.fieldSpec.push(['(((f.identifier)))', 'array', ((( f.options['fill'].value ))).prototype.fieldSpec, function () { return (((f | arrayFillSize))); }, ((( f | arrayLength )))]);
 ((*- elif f.type_id == 'string' *))
-((( m.identifier | js_classnameify ))).prototype.fieldSpec.push(['(((f.identifier)))', 'string']);
+((( m.identifier | js_classnameify ))).prototype.fieldSpec.push(['(((f.identifier)))', 'string', ((( f | arrayLength )))]);
 ((*- else *))
 ((( m.identifier | js_classnameify ))).prototype.fieldSpec.push(['(((f.identifier)))', ((( f.type_id ))).prototype.fieldSpec]);
 ((*- endif *))

--- a/javascript/sbp/acquisition.js
+++ b/javascript/sbp/acquisition.js
@@ -19,7 +19,9 @@
 ***********************/
 
 var SBP = require('./sbp');
-var Parser = require('binary-parser').Parser;
+var Parser = require('./parser');
+var Int64 = require('node-int64');
+var UInt64 = require('cuint').UINT64;
 var GnssSignal = require("./gnss_signal").GnssSignal;
 
 /**
@@ -115,9 +117,9 @@ MsgAcqResultDepA.prototype.fieldSpec.push(['prn', 'writeUInt8', 1]);
  * @field bin_width number (unsigned 16-bit int, 2 bytes) Acq frequency bin width
  * @field timestamp number (unsigned 32-bit int, 4 bytes) Timestamp of the job complete event
  * @field time_spent number (unsigned 32-bit int, 4 bytes) Time spent to search for sid.code
- * @field cf_min number (unsigned 32-bit int, 4 bytes) Doppler range lowest frequency
- * @field cf_max number (unsigned 32-bit int, 4 bytes) Doppler range highest frequency
- * @field cf number (unsigned 32-bit int, 4 bytes) Doppler value of detected peak. Only valid if status is '1'
+ * @field cf_min number (signed 32-bit int, 4 bytes) Doppler range lowest frequency
+ * @field cf_max number (signed 32-bit int, 4 bytes) Doppler range highest frequency
+ * @field cf number (signed 32-bit int, 4 bytes) Doppler value of detected peak. Only valid if status is '1'
  * @field cp number (unsigned 32-bit int, 4 bytes) Codephase of detected peak. Only valid if status is '1'
  *
  * @param sbp An SBP object with a payload to be decoded.
@@ -142,9 +144,9 @@ AcqSvProfile.prototype.parser = new Parser()
   .uint16('bin_width')
   .uint32('timestamp')
   .uint32('time_spent')
-  .uint32('cf_min')
-  .uint32('cf_max')
-  .uint32('cf')
+  .int32('cf_min')
+  .int32('cf_max')
+  .int32('cf')
   .uint32('cp');
 AcqSvProfile.prototype.fieldSpec = [];
 AcqSvProfile.prototype.fieldSpec.push(['job_type', 'writeUInt8', 1]);
@@ -155,9 +157,9 @@ AcqSvProfile.prototype.fieldSpec.push(['sid', GnssSignal.prototype.fieldSpec]);
 AcqSvProfile.prototype.fieldSpec.push(['bin_width', 'writeUInt16LE', 2]);
 AcqSvProfile.prototype.fieldSpec.push(['timestamp', 'writeUInt32LE', 4]);
 AcqSvProfile.prototype.fieldSpec.push(['time_spent', 'writeUInt32LE', 4]);
-AcqSvProfile.prototype.fieldSpec.push(['cf_min', 'writeUInt32LE', 4]);
-AcqSvProfile.prototype.fieldSpec.push(['cf_max', 'writeUInt32LE', 4]);
-AcqSvProfile.prototype.fieldSpec.push(['cf', 'writeUInt32LE', 4]);
+AcqSvProfile.prototype.fieldSpec.push(['cf_min', 'writeInt32LE', 4]);
+AcqSvProfile.prototype.fieldSpec.push(['cf_max', 'writeInt32LE', 4]);
+AcqSvProfile.prototype.fieldSpec.push(['cf', 'writeInt32LE', 4]);
 AcqSvProfile.prototype.fieldSpec.push(['cp', 'writeUInt32LE', 4]);
 
 /**
@@ -186,7 +188,7 @@ MsgAcqSvProfile.prototype.parser = new Parser()
   .endianess('little')
   .array('acq_sv_profile', { type: AcqSvProfile.prototype.parser, readUntil: 'eof' });
 MsgAcqSvProfile.prototype.fieldSpec = [];
-MsgAcqSvProfile.prototype.fieldSpec.push(['acq_sv_profile', 'array', AcqSvProfile.prototype.fieldSpec, function () { return this.fields.array.length; }]);
+MsgAcqSvProfile.prototype.fieldSpec.push(['acq_sv_profile', 'array', AcqSvProfile.prototype.fieldSpec, function () { return this.fields.array.length; }, null]);
 
 module.exports = {
   0x0014: MsgAcqResult,

--- a/javascript/sbp/bootload.js
+++ b/javascript/sbp/bootload.js
@@ -21,7 +21,9 @@
 ***********************/
 
 var SBP = require('./sbp');
-var Parser = require('binary-parser').Parser;
+var Parser = require('./parser');
+var Int64 = require('node-int64');
+var UInt64 = require('cuint').UINT64;
 
 /**
  * SBP class for message MSG_BOOTLOADER_HANDSHAKE_REQ (0x00B3).
@@ -78,7 +80,7 @@ MsgBootloaderHandshakeResp.prototype.parser = new Parser()
   .string('version', { greedy: true });
 MsgBootloaderHandshakeResp.prototype.fieldSpec = [];
 MsgBootloaderHandshakeResp.prototype.fieldSpec.push(['flags', 'writeUInt32LE', 4]);
-MsgBootloaderHandshakeResp.prototype.fieldSpec.push(['version', 'string']);
+MsgBootloaderHandshakeResp.prototype.fieldSpec.push(['version', 'string', null]);
 
 /**
  * SBP class for message MSG_BOOTLOADER_JUMP_TO_APP (0x00B1).
@@ -162,7 +164,7 @@ MsgNapDeviceDnaResp.prototype.parser = new Parser()
   .endianess('little')
   .array('dna', { length: 8, type: 'uint8' });
 MsgNapDeviceDnaResp.prototype.fieldSpec = [];
-MsgNapDeviceDnaResp.prototype.fieldSpec.push(['dna', 'array', 'writeUInt8', function () { return 1; }]);
+MsgNapDeviceDnaResp.prototype.fieldSpec.push(['dna', 'array', 'writeUInt8', function () { return 1; }, 8]);
 
 /**
  * SBP class for message MSG_BOOTLOADER_HANDSHAKE_DEP_A (0x00B0).
@@ -189,7 +191,7 @@ MsgBootloaderHandshakeDepA.prototype.parser = new Parser()
   .endianess('little')
   .array('handshake', { type: 'uint8', readUntil: 'eof' });
 MsgBootloaderHandshakeDepA.prototype.fieldSpec = [];
-MsgBootloaderHandshakeDepA.prototype.fieldSpec.push(['handshake', 'array', 'writeUInt8', function () { return 1; }]);
+MsgBootloaderHandshakeDepA.prototype.fieldSpec.push(['handshake', 'array', 'writeUInt8', function () { return 1; }, null]);
 
 module.exports = {
   0x00B3: MsgBootloaderHandshakeReq,

--- a/javascript/sbp/ext_events.js
+++ b/javascript/sbp/ext_events.js
@@ -20,7 +20,9 @@
 ***********************/
 
 var SBP = require('./sbp');
-var Parser = require('binary-parser').Parser;
+var Parser = require('./parser');
+var Int64 = require('node-int64');
+var UInt64 = require('cuint').UINT64;
 
 /**
  * SBP class for message MSG_EXT_EVENT (0x0101).

--- a/javascript/sbp/file_io.js
+++ b/javascript/sbp/file_io.js
@@ -24,7 +24,9 @@
 ***********************/
 
 var SBP = require('./sbp');
-var Parser = require('binary-parser').Parser;
+var Parser = require('./parser');
+var Int64 = require('node-int64');
+var UInt64 = require('cuint').UINT64;
 
 /**
  * SBP class for message MSG_FILEIO_READ_REQ (0x00A8).
@@ -66,7 +68,7 @@ MsgFileioReadReq.prototype.fieldSpec = [];
 MsgFileioReadReq.prototype.fieldSpec.push(['sequence', 'writeUInt32LE', 4]);
 MsgFileioReadReq.prototype.fieldSpec.push(['offset', 'writeUInt32LE', 4]);
 MsgFileioReadReq.prototype.fieldSpec.push(['chunk_size', 'writeUInt8', 1]);
-MsgFileioReadReq.prototype.fieldSpec.push(['filename', 'string']);
+MsgFileioReadReq.prototype.fieldSpec.push(['filename', 'string', null]);
 
 /**
  * SBP class for message MSG_FILEIO_READ_RESP (0x00A3).
@@ -99,7 +101,7 @@ MsgFileioReadResp.prototype.parser = new Parser()
   .array('contents', { type: 'uint8', readUntil: 'eof' });
 MsgFileioReadResp.prototype.fieldSpec = [];
 MsgFileioReadResp.prototype.fieldSpec.push(['sequence', 'writeUInt32LE', 4]);
-MsgFileioReadResp.prototype.fieldSpec.push(['contents', 'array', 'writeUInt8', function () { return 1; }]);
+MsgFileioReadResp.prototype.fieldSpec.push(['contents', 'array', 'writeUInt8', function () { return 1; }, null]);
 
 /**
  * SBP class for message MSG_FILEIO_READ_DIR_REQ (0x00A9).
@@ -139,7 +141,7 @@ MsgFileioReadDirReq.prototype.parser = new Parser()
 MsgFileioReadDirReq.prototype.fieldSpec = [];
 MsgFileioReadDirReq.prototype.fieldSpec.push(['sequence', 'writeUInt32LE', 4]);
 MsgFileioReadDirReq.prototype.fieldSpec.push(['offset', 'writeUInt32LE', 4]);
-MsgFileioReadDirReq.prototype.fieldSpec.push(['dirname', 'string']);
+MsgFileioReadDirReq.prototype.fieldSpec.push(['dirname', 'string', null]);
 
 /**
  * SBP class for message MSG_FILEIO_READ_DIR_RESP (0x00AA).
@@ -173,7 +175,7 @@ MsgFileioReadDirResp.prototype.parser = new Parser()
   .array('contents', { type: 'uint8', readUntil: 'eof' });
 MsgFileioReadDirResp.prototype.fieldSpec = [];
 MsgFileioReadDirResp.prototype.fieldSpec.push(['sequence', 'writeUInt32LE', 4]);
-MsgFileioReadDirResp.prototype.fieldSpec.push(['contents', 'array', 'writeUInt8', function () { return 1; }]);
+MsgFileioReadDirResp.prototype.fieldSpec.push(['contents', 'array', 'writeUInt8', function () { return 1; }, null]);
 
 /**
  * SBP class for message MSG_FILEIO_REMOVE (0x00AC).
@@ -203,7 +205,7 @@ MsgFileioRemove.prototype.parser = new Parser()
   .endianess('little')
   .string('filename', { greedy: true });
 MsgFileioRemove.prototype.fieldSpec = [];
-MsgFileioRemove.prototype.fieldSpec.push(['filename', 'string']);
+MsgFileioRemove.prototype.fieldSpec.push(['filename', 'string', null]);
 
 /**
  * SBP class for message MSG_FILEIO_WRITE_REQ (0x00AD).
@@ -243,8 +245,8 @@ MsgFileioWriteReq.prototype.parser = new Parser()
 MsgFileioWriteReq.prototype.fieldSpec = [];
 MsgFileioWriteReq.prototype.fieldSpec.push(['sequence', 'writeUInt32LE', 4]);
 MsgFileioWriteReq.prototype.fieldSpec.push(['offset', 'writeUInt32LE', 4]);
-MsgFileioWriteReq.prototype.fieldSpec.push(['filename', 'string']);
-MsgFileioWriteReq.prototype.fieldSpec.push(['data', 'array', 'writeUInt8', function () { return 1; }]);
+MsgFileioWriteReq.prototype.fieldSpec.push(['filename', 'string', null]);
+MsgFileioWriteReq.prototype.fieldSpec.push(['data', 'array', 'writeUInt8', function () { return 1; }, null]);
 
 /**
  * SBP class for message MSG_FILEIO_WRITE_RESP (0x00AB).

--- a/javascript/sbp/flash.js
+++ b/javascript/sbp/flash.js
@@ -21,7 +21,9 @@
 ***********************/
 
 var SBP = require('./sbp');
-var Parser = require('binary-parser').Parser;
+var Parser = require('./parser');
+var Int64 = require('node-int64');
+var UInt64 = require('cuint').UINT64;
 
 /**
  * SBP class for message MSG_FLASH_PROGRAM (0x00E6).
@@ -59,9 +61,9 @@ MsgFlashProgram.prototype.parser = new Parser()
   .array('data', { type: 'uint8', length: 'addr_len' });
 MsgFlashProgram.prototype.fieldSpec = [];
 MsgFlashProgram.prototype.fieldSpec.push(['target', 'writeUInt8', 1]);
-MsgFlashProgram.prototype.fieldSpec.push(['addr_start', 'array', 'writeUInt8', function () { return 1; }]);
+MsgFlashProgram.prototype.fieldSpec.push(['addr_start', 'array', 'writeUInt8', function () { return 1; }, 3]);
 MsgFlashProgram.prototype.fieldSpec.push(['addr_len', 'writeUInt8', 1]);
-MsgFlashProgram.prototype.fieldSpec.push(['data', 'array', 'writeUInt8', function () { return 1; }]);
+MsgFlashProgram.prototype.fieldSpec.push(['data', 'array', 'writeUInt8', function () { return 1; }, 'addr_len']);
 
 /**
  * SBP class for message MSG_FLASH_DONE (0x00E0).
@@ -126,7 +128,7 @@ MsgFlashReadReq.prototype.parser = new Parser()
   .uint8('addr_len');
 MsgFlashReadReq.prototype.fieldSpec = [];
 MsgFlashReadReq.prototype.fieldSpec.push(['target', 'writeUInt8', 1]);
-MsgFlashReadReq.prototype.fieldSpec.push(['addr_start', 'array', 'writeUInt8', function () { return 1; }]);
+MsgFlashReadReq.prototype.fieldSpec.push(['addr_start', 'array', 'writeUInt8', function () { return 1; }, 3]);
 MsgFlashReadReq.prototype.fieldSpec.push(['addr_len', 'writeUInt8', 1]);
 
 /**
@@ -163,7 +165,7 @@ MsgFlashReadResp.prototype.parser = new Parser()
   .uint8('addr_len');
 MsgFlashReadResp.prototype.fieldSpec = [];
 MsgFlashReadResp.prototype.fieldSpec.push(['target', 'writeUInt8', 1]);
-MsgFlashReadResp.prototype.fieldSpec.push(['addr_start', 'array', 'writeUInt8', function () { return 1; }]);
+MsgFlashReadResp.prototype.fieldSpec.push(['addr_start', 'array', 'writeUInt8', function () { return 1; }, 3]);
 MsgFlashReadResp.prototype.fieldSpec.push(['addr_len', 'writeUInt8', 1]);
 
 /**
@@ -306,7 +308,7 @@ MsgStmUniqueIdResp.prototype.parser = new Parser()
   .endianess('little')
   .array('stm_id', { length: 12, type: 'uint8' });
 MsgStmUniqueIdResp.prototype.fieldSpec = [];
-MsgStmUniqueIdResp.prototype.fieldSpec.push(['stm_id', 'array', 'writeUInt8', function () { return 1; }]);
+MsgStmUniqueIdResp.prototype.fieldSpec.push(['stm_id', 'array', 'writeUInt8', function () { return 1; }, 12]);
 
 /**
  * SBP class for message MSG_M25_FLASH_WRITE_STATUS (0x00F3).
@@ -334,7 +336,7 @@ MsgM25FlashWriteStatus.prototype.parser = new Parser()
   .endianess('little')
   .array('status', { length: 1, type: 'uint8' });
 MsgM25FlashWriteStatus.prototype.fieldSpec = [];
-MsgM25FlashWriteStatus.prototype.fieldSpec.push(['status', 'array', 'writeUInt8', function () { return 1; }]);
+MsgM25FlashWriteStatus.prototype.fieldSpec.push(['status', 'array', 'writeUInt8', function () { return 1; }, 1]);
 
 module.exports = {
   0x00E6: MsgFlashProgram,

--- a/javascript/sbp/gnss_signal.js
+++ b/javascript/sbp/gnss_signal.js
@@ -19,7 +19,9 @@
 ***********************/
 
 var SBP = require('./sbp');
-var Parser = require('binary-parser').Parser;
+var Parser = require('./parser');
+var Int64 = require('node-int64');
+var UInt64 = require('cuint').UINT64;
 
 /**
  * SBP class for message fragment GnssSignal

--- a/javascript/sbp/logging.js
+++ b/javascript/sbp/logging.js
@@ -19,7 +19,9 @@
 ***********************/
 
 var SBP = require('./sbp');
-var Parser = require('binary-parser').Parser;
+var Parser = require('./parser');
+var Int64 = require('node-int64');
+var UInt64 = require('cuint').UINT64;
 
 /**
  * SBP class for message MSG_LOG (0x0401).
@@ -51,7 +53,7 @@ MsgLog.prototype.parser = new Parser()
   .string('text', { greedy: true });
 MsgLog.prototype.fieldSpec = [];
 MsgLog.prototype.fieldSpec.push(['level', 'writeUInt8', 1]);
-MsgLog.prototype.fieldSpec.push(['text', 'string']);
+MsgLog.prototype.fieldSpec.push(['text', 'string', null]);
 
 /**
  * SBP class for message MSG_TWEET (0x0012).
@@ -78,7 +80,7 @@ MsgTweet.prototype.parser = new Parser()
   .endianess('little')
   .string('tweet', { length: 140 });
 MsgTweet.prototype.fieldSpec = [];
-MsgTweet.prototype.fieldSpec.push(['tweet', 'string']);
+MsgTweet.prototype.fieldSpec.push(['tweet', 'string', 140]);
 
 /**
  * SBP class for message MSG_PRINT_DEP (0x0010).
@@ -105,7 +107,7 @@ MsgPrintDep.prototype.parser = new Parser()
   .endianess('little')
   .string('text', { greedy: true });
 MsgPrintDep.prototype.fieldSpec = [];
-MsgPrintDep.prototype.fieldSpec.push(['text', 'string']);
+MsgPrintDep.prototype.fieldSpec.push(['text', 'string', null]);
 
 module.exports = {
   0x0401: MsgLog,

--- a/javascript/sbp/navigation.js
+++ b/javascript/sbp/navigation.js
@@ -26,7 +26,9 @@
 ***********************/
 
 var SBP = require('./sbp');
-var Parser = require('binary-parser').Parser;
+var Parser = require('./parser');
+var Int64 = require('node-int64');
+var UInt64 = require('cuint').UINT64;
 
 /**
  * SBP class for message MSG_GPS_TIME (0x0100).

--- a/javascript/sbp/observation.js
+++ b/javascript/sbp/observation.js
@@ -19,7 +19,9 @@
 ***********************/
 
 var SBP = require('./sbp');
-var Parser = require('binary-parser').Parser;
+var Parser = require('./parser');
+var Int64 = require('node-int64');
+var UInt64 = require('cuint').UINT64;
 var GnssSignal = require("./gnss_signal").GnssSignal;
 
 /**
@@ -187,7 +189,7 @@ MsgObs.prototype.parser = new Parser()
   .array('obs', { type: PackedObsContent.prototype.parser, readUntil: 'eof' });
 MsgObs.prototype.fieldSpec = [];
 MsgObs.prototype.fieldSpec.push(['header', ObservationHeader.prototype.fieldSpec]);
-MsgObs.prototype.fieldSpec.push(['obs', 'array', PackedObsContent.prototype.fieldSpec, function () { return this.fields.array.length; }]);
+MsgObs.prototype.fieldSpec.push(['obs', 'array', PackedObsContent.prototype.fieldSpec, function () { return this.fields.array.length; }, null]);
 
 /**
  * SBP class for message MSG_BASE_POS_LLH (0x0044).
@@ -434,9 +436,9 @@ MsgEphemerisSbas.prototype.parser = new Parser()
   .doublele('a_gf1');
 MsgEphemerisSbas.prototype.fieldSpec = [];
 MsgEphemerisSbas.prototype.fieldSpec.push(['common', EphemerisCommonContent.prototype.fieldSpec]);
-MsgEphemerisSbas.prototype.fieldSpec.push(['pos', 'array', 'writeDoubleLE', function () { return 8; }]);
-MsgEphemerisSbas.prototype.fieldSpec.push(['vel', 'array', 'writeDoubleLE', function () { return 8; }]);
-MsgEphemerisSbas.prototype.fieldSpec.push(['acc', 'array', 'writeDoubleLE', function () { return 8; }]);
+MsgEphemerisSbas.prototype.fieldSpec.push(['pos', 'array', 'writeDoubleLE', function () { return 8; }, 3]);
+MsgEphemerisSbas.prototype.fieldSpec.push(['vel', 'array', 'writeDoubleLE', function () { return 8; }, 3]);
+MsgEphemerisSbas.prototype.fieldSpec.push(['acc', 'array', 'writeDoubleLE', function () { return 8; }, 3]);
 MsgEphemerisSbas.prototype.fieldSpec.push(['a_gf0', 'writeDoubleLE', 8]);
 MsgEphemerisSbas.prototype.fieldSpec.push(['a_gf1', 'writeDoubleLE', 8]);
 
@@ -481,9 +483,9 @@ MsgEphemerisGlo.prototype.fieldSpec = [];
 MsgEphemerisGlo.prototype.fieldSpec.push(['common', EphemerisCommonContent.prototype.fieldSpec]);
 MsgEphemerisGlo.prototype.fieldSpec.push(['gamma', 'writeDoubleLE', 8]);
 MsgEphemerisGlo.prototype.fieldSpec.push(['tau', 'writeDoubleLE', 8]);
-MsgEphemerisGlo.prototype.fieldSpec.push(['pos', 'array', 'writeDoubleLE', function () { return 8; }]);
-MsgEphemerisGlo.prototype.fieldSpec.push(['vel', 'array', 'writeDoubleLE', function () { return 8; }]);
-MsgEphemerisGlo.prototype.fieldSpec.push(['acc', 'array', 'writeDoubleLE', function () { return 8; }]);
+MsgEphemerisGlo.prototype.fieldSpec.push(['pos', 'array', 'writeDoubleLE', function () { return 8; }, 3]);
+MsgEphemerisGlo.prototype.fieldSpec.push(['vel', 'array', 'writeDoubleLE', function () { return 8; }, 3]);
+MsgEphemerisGlo.prototype.fieldSpec.push(['acc', 'array', 'writeDoubleLE', function () { return 8; }, 3]);
 
 /**
  * SBP class for message MSG_EPHEMERIS_DEP_D (0x0080).
@@ -1059,7 +1061,7 @@ MsgObsDepA.prototype.parser = new Parser()
   .array('obs', { type: PackedObsContentDepA.prototype.parser, readUntil: 'eof' });
 MsgObsDepA.prototype.fieldSpec = [];
 MsgObsDepA.prototype.fieldSpec.push(['header', ObservationHeader.prototype.fieldSpec]);
-MsgObsDepA.prototype.fieldSpec.push(['obs', 'array', PackedObsContentDepA.prototype.fieldSpec, function () { return this.fields.array.length; }]);
+MsgObsDepA.prototype.fieldSpec.push(['obs', 'array', PackedObsContentDepA.prototype.fieldSpec, function () { return this.fields.array.length; }, null]);
 
 /**
  * SBP class for message MSG_OBS_DEP_B (0x0043).
@@ -1092,7 +1094,7 @@ MsgObsDepB.prototype.parser = new Parser()
   .array('obs', { type: PackedObsContentDepB.prototype.parser, readUntil: 'eof' });
 MsgObsDepB.prototype.fieldSpec = [];
 MsgObsDepB.prototype.fieldSpec.push(['header', ObservationHeader.prototype.fieldSpec]);
-MsgObsDepB.prototype.fieldSpec.push(['obs', 'array', PackedObsContentDepB.prototype.fieldSpec, function () { return this.fields.array.length; }]);
+MsgObsDepB.prototype.fieldSpec.push(['obs', 'array', PackedObsContentDepB.prototype.fieldSpec, function () { return this.fields.array.length; }, null]);
 
 /**
  * SBP class for message MSG_IONO (0x0090).

--- a/javascript/sbp/parser.js
+++ b/javascript/sbp/parser.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2016 Swift Navigation Inc.
+ * Contact: Joshua Gross <josh@swift-nav.com>
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+var Parser = require('binary-parser').Parser;
+
+/**
+ * Add `uint64` to Parser prototype.
+ */
+Parser.prototype.uint64 = function uint64 (fieldName, options) {
+  return this.setNextParser('uint64', fieldName, Object.assign({}, options, {
+    formatter: function (recv_time) {
+      var UInt64 = require('cuint').UINT64;
+      var low = buffer.readUInt32LE(offset);
+      offset += 4;
+      var high = buffer.readUInt32LE(offset);
+      offset += 4;
+      return new UInt64(low, high);
+    }
+  }));
+}
+
+/**
+ * Replace the original compile function to pass in `require` (???)
+ */
+Parser.prototype.compile = function() {
+  var compiledCode = this.getCode();
+  this.compiled = function (buffer, callback, constructorFn) {
+    return (new Function('buffer', 'callback', 'constructorFn', 'require', compiledCode)).call(this, buffer, callback, constructorFn, require);
+  };
+};
+
+module.exports = Parser;

--- a/javascript/sbp/piksi.js
+++ b/javascript/sbp/piksi.js
@@ -20,7 +20,9 @@
 ***********************/
 
 var SBP = require('./sbp');
-var Parser = require('binary-parser').Parser;
+var Parser = require('./parser');
+var Int64 = require('node-int64');
+var UInt64 = require('cuint').UINT64;
 var GnssSignal = require("./gnss_signal").GnssSignal;
 
 /**
@@ -222,7 +224,7 @@ MsgThreadState.prototype.parser = new Parser()
   .uint16('cpu')
   .uint32('stack_free');
 MsgThreadState.prototype.fieldSpec = [];
-MsgThreadState.prototype.fieldSpec.push(['name', 'string']);
+MsgThreadState.prototype.fieldSpec.push(['name', 'string', 20]);
 MsgThreadState.prototype.fieldSpec.push(['cpu', 'writeUInt16LE', 2]);
 MsgThreadState.prototype.fieldSpec.push(['stack_free', 'writeUInt32LE', 4]);
 

--- a/javascript/sbp/settings.js
+++ b/javascript/sbp/settings.js
@@ -23,7 +23,9 @@
 ***********************/
 
 var SBP = require('./sbp');
-var Parser = require('binary-parser').Parser;
+var Parser = require('./parser');
+var Int64 = require('node-int64');
+var UInt64 = require('cuint').UINT64;
 
 /**
  * SBP class for message MSG_SETTINGS_SAVE (0x00A1).
@@ -75,7 +77,7 @@ MsgSettingsWrite.prototype.parser = new Parser()
   .endianess('little')
   .string('setting', { greedy: true });
 MsgSettingsWrite.prototype.fieldSpec = [];
-MsgSettingsWrite.prototype.fieldSpec.push(['setting', 'string']);
+MsgSettingsWrite.prototype.fieldSpec.push(['setting', 'string', null]);
 
 /**
  * SBP class for message MSG_SETTINGS_READ_REQ (0x00A4).
@@ -104,7 +106,7 @@ MsgSettingsReadReq.prototype.parser = new Parser()
   .endianess('little')
   .string('setting', { greedy: true });
 MsgSettingsReadReq.prototype.fieldSpec = [];
-MsgSettingsReadReq.prototype.fieldSpec.push(['setting', 'string']);
+MsgSettingsReadReq.prototype.fieldSpec.push(['setting', 'string', null]);
 
 /**
  * SBP class for message MSG_SETTINGS_READ_RESP (0x00A5).
@@ -132,7 +134,7 @@ MsgSettingsReadResp.prototype.parser = new Parser()
   .endianess('little')
   .string('setting', { greedy: true });
 MsgSettingsReadResp.prototype.fieldSpec = [];
-MsgSettingsReadResp.prototype.fieldSpec.push(['setting', 'string']);
+MsgSettingsReadResp.prototype.fieldSpec.push(['setting', 'string', null]);
 
 /**
  * SBP class for message MSG_SETTINGS_READ_BY_INDEX_REQ (0x00A2).
@@ -197,7 +199,7 @@ MsgSettingsReadByIndexResp.prototype.parser = new Parser()
   .string('setting', { greedy: true });
 MsgSettingsReadByIndexResp.prototype.fieldSpec = [];
 MsgSettingsReadByIndexResp.prototype.fieldSpec.push(['index', 'writeUInt16LE', 2]);
-MsgSettingsReadByIndexResp.prototype.fieldSpec.push(['setting', 'string']);
+MsgSettingsReadByIndexResp.prototype.fieldSpec.push(['setting', 'string', null]);
 
 /**
  * SBP class for message MSG_SETTINGS_READ_BY_INDEX_DONE (0x00A6).
@@ -249,7 +251,7 @@ MsgSettingsRegister.prototype.parser = new Parser()
   .endianess('little')
   .string('setting', { greedy: true });
 MsgSettingsRegister.prototype.fieldSpec = [];
-MsgSettingsRegister.prototype.fieldSpec.push(['setting', 'string']);
+MsgSettingsRegister.prototype.fieldSpec.push(['setting', 'string', null]);
 
 module.exports = {
   0x00A1: MsgSettingsSave,

--- a/javascript/sbp/system.js
+++ b/javascript/sbp/system.js
@@ -19,7 +19,9 @@
 ***********************/
 
 var SBP = require('./sbp');
-var Parser = require('binary-parser').Parser;
+var Parser = require('./parser');
+var Int64 = require('node-int64');
+var UInt64 = require('cuint').UINT64;
 
 /**
  * SBP class for message MSG_STARTUP (0xFF00).

--- a/javascript/sbp/tracking.js
+++ b/javascript/sbp/tracking.js
@@ -19,8 +19,103 @@
 ***********************/
 
 var SBP = require('./sbp');
-var Parser = require('binary-parser').Parser;
+var Parser = require('./parser');
+var Int64 = require('node-int64');
+var UInt64 = require('cuint').UINT64;
 var GnssSignal = require("./gnss_signal").GnssSignal;
+var ObsGPSTime = require("./observation").ObsGPSTime;
+var CarrierPhase = require("./observation").CarrierPhase;
+
+/**
+ * SBP class for message MSG_TRACKING_STATE_DETAILED (0x0011).
+ *
+ * The tracking message returns a set tracking channel parameters for a single
+ * tracking channel useful for debugging issues.
+ *
+ * Fields in the SBP payload (`sbp.payload`):
+ * @field recv_time number (unsigned 64-bit int, 8 bytes) Receiver clock time.
+ * @field tot ObsGPSTime Time of transmission of signal from satellite.
+ * @field P number (unsigned 32-bit int, 4 bytes) Pseudorange observation.
+ * @field P_std number (unsigned 16-bit int, 2 bytes) Pseudorange observation standard deviation.
+ * @field L CarrierPhase Carrier phase observation with typical sign convention. Only valid when PLL
+ *   pessimistic lock is achieved.
+ * @field cn0 number (unsigned 8-bit int, 1 byte) Carrier-to-Noise density
+ * @field lock number (unsigned 16-bit int, 2 bytes) Lock indicator. This value changes whenever a satellite signal has lost and
+ *   regained lock, indicating that the carrier phase ambiguity may have changed.
+ * @field sid GnssSignal GNSS signal identifier.
+ * @field doppler number (signed 32-bit int, 4 bytes) Carrier Doppler frequency.
+ * @field doppler_std number (unsigned 16-bit int, 2 bytes) Carrier Doppler frequency standard deviation.
+ * @field uptime number (unsigned 32-bit int, 4 bytes) Number of seconds of continuous tracking. Specifies how much time signal is in
+ *   continuous track.
+ * @field clock_offset number (unsigned 16-bit int, 2 bytes) TCXO clock offset.
+ * @field clock_drift number (unsigned 16-bit int, 2 bytes) TCXO clock drift.
+ * @field corr_spacing number (unsigned 16-bit int, 2 bytes) Early-Prompt (EP) and Prompt-Late (PL) correlators spacing.
+ * @field acceleration number (unsigned 8-bit int, 1 byte) Acceleration. Valid only when acceleration valid flag is set.
+ * @field sync_flags number (unsigned 8-bit int, 1 byte) Synchronization status flags.
+ * @field tow_flags number (unsigned 8-bit int, 1 byte) TOW status flags.
+ * @field track_flags number (unsigned 8-bit int, 1 byte) Tracking loop status flags.
+ * @field nav_flags number (unsigned 8-bit int, 1 byte) Navigation data status flags.
+ * @field pset_flags number (unsigned 8-bit int, 1 byte) Parameters sets flags.
+ * @field misc_flags number (unsigned 8-bit int, 1 byte) Miscellaneous flags.
+ *
+ * @param sbp An SBP object with a payload to be decoded.
+ */
+var MsgTrackingStateDetailed = function (sbp, fields) {
+  SBP.call(this, sbp);
+  this.messageType = "MSG_TRACKING_STATE_DETAILED";
+  this.fields = (fields || this.parser.parse(sbp.payload));
+
+  return this;
+};
+MsgTrackingStateDetailed.prototype = Object.create(SBP.prototype);
+MsgTrackingStateDetailed.prototype.messageType = "MSG_TRACKING_STATE_DETAILED";
+MsgTrackingStateDetailed.prototype.msg_type = 0x0011;
+MsgTrackingStateDetailed.prototype.constructor = MsgTrackingStateDetailed;
+MsgTrackingStateDetailed.prototype.parser = new Parser()
+  .endianess('little')
+  .uint64('recv_time')
+  .nest('tot', { type: ObsGPSTime.prototype.parser })
+  .uint32('P')
+  .uint16('P_std')
+  .nest('L', { type: CarrierPhase.prototype.parser })
+  .uint8('cn0')
+  .uint16('lock')
+  .nest('sid', { type: GnssSignal.prototype.parser })
+  .int32('doppler')
+  .uint16('doppler_std')
+  .uint32('uptime')
+  .uint16('clock_offset')
+  .uint16('clock_drift')
+  .uint16('corr_spacing')
+  .uint8('acceleration')
+  .uint8('sync_flags')
+  .uint8('tow_flags')
+  .uint8('track_flags')
+  .uint8('nav_flags')
+  .uint8('pset_flags')
+  .uint8('misc_flags');
+MsgTrackingStateDetailed.prototype.fieldSpec = [];
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['recv_time', 'writeUInt64LE', 8]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['tot', ObsGPSTime.prototype.fieldSpec]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['P', 'writeUInt32LE', 4]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['P_std', 'writeUInt16LE', 2]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['L', CarrierPhase.prototype.fieldSpec]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['cn0', 'writeUInt8', 1]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['lock', 'writeUInt16LE', 2]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['sid', GnssSignal.prototype.fieldSpec]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['doppler', 'writeInt32LE', 4]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['doppler_std', 'writeUInt16LE', 2]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['uptime', 'writeUInt32LE', 4]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['clock_offset', 'writeUInt16LE', 2]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['clock_drift', 'writeUInt16LE', 2]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['corr_spacing', 'writeUInt16LE', 2]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['acceleration', 'writeUInt8', 1]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['sync_flags', 'writeUInt8', 1]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['tow_flags', 'writeUInt8', 1]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['track_flags', 'writeUInt8', 1]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['nav_flags', 'writeUInt8', 1]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['pset_flags', 'writeUInt8', 1]);
+MsgTrackingStateDetailed.prototype.fieldSpec.push(['misc_flags', 'writeUInt8', 1]);
 
 /**
  * SBP class for message fragment TrackingChannelState
@@ -63,7 +158,7 @@ TrackingChannelState.prototype.fieldSpec.push(['cn0', 'writeFloatLE', 4]);
  * satellites.
  *
  * Fields in the SBP payload (`sbp.payload`):
- * @field states array Satellite tracking channel state
+ * @field states array Signal tracking channel state
  *
  * @param sbp An SBP object with a payload to be decoded.
  */
@@ -82,7 +177,7 @@ MsgTrackingState.prototype.parser = new Parser()
   .endianess('little')
   .array('states', { type: TrackingChannelState.prototype.parser, readUntil: 'eof' });
 MsgTrackingState.prototype.fieldSpec = [];
-MsgTrackingState.prototype.fieldSpec.push(['states', 'array', TrackingChannelState.prototype.fieldSpec, function () { return this.fields.array.length; }]);
+MsgTrackingState.prototype.fieldSpec.push(['states', 'array', TrackingChannelState.prototype.fieldSpec, function () { return this.fields.array.length; }, null]);
 
 /**
  * SBP class for message fragment TrackingChannelCorrelation
@@ -145,7 +240,7 @@ MsgTrackingIq.prototype.parser = new Parser()
 MsgTrackingIq.prototype.fieldSpec = [];
 MsgTrackingIq.prototype.fieldSpec.push(['channel', 'writeUInt8', 1]);
 MsgTrackingIq.prototype.fieldSpec.push(['sid', GnssSignal.prototype.fieldSpec]);
-MsgTrackingIq.prototype.fieldSpec.push(['corrs', 'array', TrackingChannelCorrelation.prototype.fieldSpec, function () { return this.fields.array.length; }]);
+MsgTrackingIq.prototype.fieldSpec.push(['corrs', 'array', TrackingChannelCorrelation.prototype.fieldSpec, function () { return this.fields.array.length; }, 3]);
 
 /**
  * SBP class for message fragment TrackingChannelStateDepA
@@ -204,9 +299,11 @@ MsgTrackingStateDepA.prototype.parser = new Parser()
   .endianess('little')
   .array('states', { type: TrackingChannelStateDepA.prototype.parser, readUntil: 'eof' });
 MsgTrackingStateDepA.prototype.fieldSpec = [];
-MsgTrackingStateDepA.prototype.fieldSpec.push(['states', 'array', TrackingChannelStateDepA.prototype.fieldSpec, function () { return this.fields.array.length; }]);
+MsgTrackingStateDepA.prototype.fieldSpec.push(['states', 'array', TrackingChannelStateDepA.prototype.fieldSpec, function () { return this.fields.array.length; }, null]);
 
 module.exports = {
+  0x0011: MsgTrackingStateDetailed,
+  MsgTrackingStateDetailed: MsgTrackingStateDetailed,
   TrackingChannelState: TrackingChannelState,
   0x0013: MsgTrackingState,
   MsgTrackingState: MsgTrackingState,

--- a/javascript/sbp/user.js
+++ b/javascript/sbp/user.js
@@ -19,7 +19,9 @@
 ***********************/
 
 var SBP = require('./sbp');
-var Parser = require('binary-parser').Parser;
+var Parser = require('./parser');
+var Int64 = require('node-int64');
+var UInt64 = require('cuint').UINT64;
 
 /**
  * SBP class for message MSG_USER_DATA (0x0800).
@@ -47,7 +49,7 @@ MsgUserData.prototype.parser = new Parser()
   .endianess('little')
   .array('contents', { type: 'uint8', readUntil: 'eof' });
 MsgUserData.prototype.fieldSpec = [];
-MsgUserData.prototype.fieldSpec.push(['contents', 'array', 'writeUInt8', function () { return 1; }]);
+MsgUserData.prototype.fieldSpec.push(['contents', 'array', 'writeUInt8', function () { return 1; }, null]);
 
 module.exports = {
   0x0800: MsgUserData,

--- a/javascript/tests/test_decode.js
+++ b/javascript/tests/test_decode.js
@@ -18,10 +18,10 @@ var messageTypesTable = require(path.resolve(__dirname, '../sbp/')).sbpMessageTy
 var constructMsg = require(path.resolve(__dirname, '../sbp/construct'));
 var utils = require('./utils');
 
-var yamlFiles = utils.getYamlSpecs();
+var yamlTestFiles = utils.getYamlTests();
 
-describe('test packages based on YAML descriptors', function () {
-  yamlFiles.map(function (filename) {
+describe('test packages based on YAML test files', function () {
+  yamlTestFiles.map(function (filename) {
     describe(filename, function () {
       var yamlConfig = yaml.safeLoad(fs.readFileSync(filename));
       yamlConfig.tests.map(function (testSpec, i) {
@@ -47,7 +47,13 @@ describe('test packages based on YAML descriptors', function () {
           });
           it('should serialize back to JSON properly', function () {
             var msg = decodeMsg();
-            assert.deepEqual(JSON.parse(JSON.stringify(msg)), JSON.parse(testSpec['raw_json']));
+
+            var expected = JSON.parse(testSpec['raw_json']);
+
+            // UInt64s are stringified as strings, not bare numbers in JSON, so...
+            var actual = JSON.parse(JSON.stringify(msg).replace(/"([0-9]+)"/, '$1'));
+
+            assert.deepEqual(actual, expected);
           });
           it('should be identical to constructed message with identical fields', function () {
             var msg = decodeMsg();

--- a/javascript/tests/test_dispatch_decoder.js
+++ b/javascript/tests/test_dispatch_decoder.js
@@ -17,10 +17,10 @@ var Readable = require('stream').Readable;
 var dispatch = require(path.resolve(__dirname, '../sbp/')).dispatch;
 var utils = require('./utils');
 
-var yamlFiles = utils.getYamlSpecs();
+var yamlTestFiles = utils.getYamlTests();
 
 describe('test packages based on YAML descriptors, through the dispatcher', function () {
-  yamlFiles.map(function (filename) {
+  yamlTestFiles.map(function (filename) {
     describe(filename, function () {
       var yamlConfig = yaml.safeLoad(fs.readFileSync(filename));
       yamlConfig.tests.map(function (testSpec, i) {

--- a/javascript/tests/test_types.js
+++ b/javascript/tests/test_types.js
@@ -1,0 +1,131 @@
+/**
+ * Copyright (C) 2015 Swift Navigation Inc.
+ * Contact: Joshua Gross <josh@swift-nav.com>
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+var fs = require('fs');
+var path = require('path');
+var assert = require('assert');
+var decode = require(path.resolve(__dirname, '../sbp/')).decode;
+var messageTypesTable = require(path.resolve(__dirname, '../sbp/')).sbpMessageTypesTable;
+var constructMsg = require(path.resolve(__dirname, '../sbp/construct'));
+var utils = require('./utils');
+var Int64 = require('node-int64');
+var UInt64 = require('cuint').UINT64;
+
+function getFieldValuesFromSpecType (fieldType, line, previousValues) {
+  if (Array.isArray(fieldType)) {
+    return getFieldValuesFromSpec(fieldType);
+  } else if (fieldType === 'writeFloatLE') {
+    return (Math.random()*1000000) + Math.random();
+  } else if (fieldType === 'writeDoubleLE') {
+    return (Math.random()*1000000) + Math.random();
+  } else if (fieldType === 'writeInt32LE') {
+    return Math.floor(Math.random() * (Math.pow(2, 31) - 1)) * (Math.random() > 0.5 ? 1 : -1);
+  } else if (fieldType === 'writeInt16LE') {
+    return Math.floor(Math.random() * (Math.pow(2, 15) - 1)) * (Math.random() > 0.5 ? 1 : -1);
+  } else if (fieldType === 'writeUInt64LE') {
+    var int1 = Math.floor(Math.random() * (Math.pow(2, 24) - 1));
+    var int2 = Math.floor(Math.random() * (Math.pow(2, 24) - 1));
+    return new UInt64(int1, int2);
+  } else if (fieldType === 'writeUInt32LE') {
+    return Math.floor(Math.random() * (Math.pow(2, 32) - 1));
+  } else if (fieldType === 'writeUInt16LE') {
+    return Math.floor(Math.random() * (Math.pow(2, 16) - 1));
+  } else if (fieldType === 'writeUInt8') {
+    // we keep uint8s artificially small, because they often represent lengths of arrays
+    return Math.floor(Math.random() * 10);
+  } else if (fieldType === 'string') {
+    var strLength = line[2];
+    if (!strLength) {
+      return 'foobar';
+    }
+
+    var str = '';
+    for (var i = 0; i < strLength; i++) {
+      str += 'x';
+    }
+    return str;
+  } else if (fieldType === 'array') {
+    var sizeField = line[4];
+    var randomSize = (Math.floor(Math.random() * 3) + 2);
+    var numElements = (typeof sizeField === 'number' ? sizeField : (typeof sizeField === 'string' ? previousValues[sizeField] : randomSize));
+    var elements = [];
+    for (var i = 0; i < numElements; i++) {
+      elements.push(getFieldValuesFromSpecType(line[2]));
+    }
+    return elements;
+  } else {
+    throw new Error('unknown type: ' + fieldType);
+  }
+}
+
+function getFieldValuesFromSpec (spec) {
+  return spec.reduce(function (acc, line) {
+    var fieldName = line[0];
+    var fieldType = line[1];
+
+    acc[fieldName] = getFieldValuesFromSpecType(fieldType, line, acc);
+
+    return acc;
+  }, {});
+}
+
+function assertFieldsMatch (spec, fields1, fields2) {
+  spec.forEach(function (fieldSpec) {
+    var fieldName = fieldSpec[0];
+    var fieldType = fieldSpec[1];
+
+    var v1 = fields1[fieldName];
+    var v2 = fields2[fieldName];
+
+    assert(typeof v1 !== 'undefined');
+    assert(typeof v2 !== 'undefined');
+
+    if (Array.isArray(fieldType)) {
+      return assertFieldsMatch(fieldType, v1, v2);
+    } else if (fieldType === 'array') {
+    } else if (fieldType.toLowerCase().indexOf('float') !== -1 || fieldType.toLowerCase().indexOf('float') !== -1) {
+    } else if (fieldType === 'writeUInt64LE') {
+      assert.equal(v1.toString(), v2.toString());
+    } else {
+      assert.equal(v1, v2);
+    }
+  });
+}
+
+describe('test packages based on descriptors of types', function () {
+  var testMsgTypes = Object.keys(messageTypesTable).filter(function (msgType) {
+    return (
+      // this message type has a greedy string followed by a greedy array, which is hard to test well
+      msgType !== 'MSG_FILEIO_WRITE_REQ'
+    );
+ });
+
+  testMsgTypes.forEach(function (k) {
+    it('should test ' + k, function () {
+      var msgLabel = k;
+      var msgConstructor = messageTypesTable[k];
+      if (!msgConstructor.prototype.msg_type) {
+        return;
+      }
+
+      var fieldSpec = msgConstructor.prototype.fieldSpec;
+      var fields = getFieldValuesFromSpec(fieldSpec);
+      var msg = constructMsg(msgConstructor, fields);
+
+      // decode msg from binary
+      var decoded = decode(msg.toBuffer());
+      var decodedFields = decoded.fields;
+
+      // compare fields
+      assertFieldsMatch(fieldSpec, fields, decodedFields);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libsbp",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "description": "libsbp bindings for JavaScript. More information here: http://swift-nav.github.io/libsbp/",
   "files": [
     "javascript/*",
@@ -14,10 +14,13 @@
   "license": "LGPL-3.0",
   "dependencies": {
     "binary-parser": "git://github.com/JoshuaGross/binary-parser.git#jgross-greedy-string",
-    "js-yaml": "^3.4.3"
+    "cuint": "^0.2.2",
+    "js-yaml": "^3.4.3",
+    "node-int64": "^0.4.0"
   },
   "devDependencies": {
     "benchmark": "^2.1.1",
+    "lodash": "^4.16.4",
     "mocha": "^2.4.5",
     "request": "^2.74.0",
     "serialport": "^4.0.1"

--- a/spec/tests/yaml/swiftnav/sbp/tracking/test_MsgTrackingStateDetailed.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/tracking/test_MsgTrackingStateDetailed.yaml
@@ -1,0 +1,256 @@
+---
+description: Unit tests for swiftnav.sbp.tracking MsgTrackingStateDetailed vNone.
+generated_on: 2016-10-27 15:44:05.108930
+package: sbp.tracking
+tests:
+
+- msg:
+    fields:
+      L:
+        f: 238
+        i: -120760716
+      P: 1149000000
+      P_std: 100
+      acceleration: 1
+      clock_drift: 10
+      clock_offset: 100
+      cn0: 0
+      corr_spacing: 2000
+      doppler: 251
+      doppler_std: 2
+      lock: 12345
+      misc_flags: 175
+      nav_flags: 173
+      pset_flags: 174
+      recv_time: 5193328303
+      sid:
+        code: 0
+        reserved: 0
+        sat: 65535
+      sync_flags: 170
+      tot:
+        tow: 86400000
+        wn: 1876
+      tow_flags: 171
+      track_flags: 172
+      uptime: 3600
+    module: sbp.tracking
+    name: MsgTrackingStateDetailed
+  msg_type: '0x11'
+  raw_json: '{"track_flags": 172, "doppler": 251, "clock_offset": 100, "msg_type":
+    17, "lock": 12345, "nav_flags": 173, "P_std": 100, "L": {"i": -120760716, "f":
+    238}, "pset_flags": 174, "P": 1149000000, "misc_flags": 175, "preamble": 85, "payload":
+    "r+aLNQEAAAAAXCYFVAdAWXxEZAB0Vs347gA5MP//AAD7AAAAAgAQDgAAZAAKANAHAaqrrK2urw==",
+    "recv_time": 5193328303, "acceleration": 1, "uptime": 3600, "sender": 49219, "cn0":
+    0, "doppler_std": 2, "tow_flags": 171, "tot": {"wn": 1876, "tow": 86400000}, "crc":
+    46779, "length": 55, "clock_drift": 10, "sid": {"code": 0, "reserved": 0, "sat":
+    65535}, "sync_flags": 170, "corr_spacing": 2000}'
+  raw_packet: VREAQ8A3r+aLNQEAAAAAXCYFVAdAWXxEZAB0Vs347gA5MP//AAD7AAAAAgAQDgAAZAAKANAHAaqrrK2ur7u2
+  sbp:
+    crc: '0xb6bb'
+    length: 55
+    msg_type: '0x11'
+    payload: r+aLNQEAAAAAXCYFVAdAWXxEZAB0Vs347gA5MP//AAD7AAAAAgAQDgAAZAAKANAHAaqrrK2urw==
+    preamble: '0x55'
+    sender: '0xc043'
+
+- msg:
+    fields:
+      L:
+        f: 238
+        i: -120760716
+      P: 1149000000
+      P_std: 100
+      acceleration: 1
+      clock_drift: 10
+      clock_offset: 100
+      cn0: 0
+      corr_spacing: 2000
+      doppler: 251
+      doppler_std: 2
+      lock: 12345
+      misc_flags: 175
+      nav_flags: 173
+      pset_flags: 174
+      recv_time: 5193330649
+      sid:
+        code: 0
+        reserved: 0
+        sat: 65535
+      sync_flags: 170
+      tot:
+        tow: 86400000
+        wn: 1876
+      tow_flags: 171
+      track_flags: 172
+      uptime: 3600
+    module: sbp.tracking
+    name: MsgTrackingStateDetailed
+  msg_type: '0x11'
+  raw_json: '{"track_flags": 172, "doppler": 251, "clock_offset": 100, "msg_type":
+    17, "lock": 12345, "nav_flags": 173, "P_std": 100, "L": {"i": -120760716, "f":
+    238}, "pset_flags": 174, "P": 1149000000, "misc_flags": 175, "preamble": 85, "payload":
+    "2e+LNQEAAAAAXCYFVAdAWXxEZAB0Vs347gA5MP//AAD7AAAAAgAQDgAAZAAKANAHAaqrrK2urw==",
+    "recv_time": 5193330649, "acceleration": 1, "uptime": 3600, "sender": 49219, "cn0":
+    0, "doppler_std": 2, "tow_flags": 171, "tot": {"wn": 1876, "tow": 86400000}, "crc":
+    7809, "length": 55, "clock_drift": 10, "sid": {"code": 0, "reserved": 0, "sat":
+    65535}, "sync_flags": 170, "corr_spacing": 2000}'
+  raw_packet: VREAQ8A32e+LNQEAAAAAXCYFVAdAWXxEZAB0Vs347gA5MP//AAD7AAAAAgAQDgAAZAAKANAHAaqrrK2ur4Ee
+  sbp:
+    crc: '0x1e81'
+    length: 55
+    msg_type: '0x11'
+    payload: 2e+LNQEAAAAAXCYFVAdAWXxEZAB0Vs347gA5MP//AAD7AAAAAgAQDgAAZAAKANAHAaqrrK2urw==
+    preamble: '0x55'
+    sender: '0xc043'
+
+- msg:
+    fields:
+      L:
+        f: 238
+        i: -120760716
+      P: 1149000000
+      P_std: 100
+      acceleration: 1
+      clock_drift: 10
+      clock_offset: 100
+      cn0: 0
+      corr_spacing: 2000
+      doppler: 251
+      doppler_std: 2
+      lock: 12345
+      misc_flags: 175
+      nav_flags: 173
+      pset_flags: 174
+      recv_time: 5193332536
+      sid:
+        code: 0
+        reserved: 0
+        sat: 65535
+      sync_flags: 170
+      tot:
+        tow: 86400000
+        wn: 1876
+      tow_flags: 171
+      track_flags: 172
+      uptime: 3600
+    module: sbp.tracking
+    name: MsgTrackingStateDetailed
+  msg_type: '0x11'
+  raw_json: '{"track_flags": 172, "doppler": 251, "clock_offset": 100, "msg_type":
+    17, "lock": 12345, "nav_flags": 173, "P_std": 100, "L": {"i": -120760716, "f":
+    238}, "pset_flags": 174, "P": 1149000000, "misc_flags": 175, "preamble": 85, "payload":
+    "OPeLNQEAAAAAXCYFVAdAWXxEZAB0Vs347gA5MP//AAD7AAAAAgAQDgAAZAAKANAHAaqrrK2urw==",
+    "recv_time": 5193332536, "acceleration": 1, "uptime": 3600, "sender": 49219, "cn0":
+    0, "doppler_std": 2, "tow_flags": 171, "tot": {"wn": 1876, "tow": 86400000}, "crc":
+    24047, "length": 55, "clock_drift": 10, "sid": {"code": 0, "reserved": 0, "sat":
+    65535}, "sync_flags": 170, "corr_spacing": 2000}'
+  raw_packet: VREAQ8A3OPeLNQEAAAAAXCYFVAdAWXxEZAB0Vs347gA5MP//AAD7AAAAAgAQDgAAZAAKANAHAaqrrK2ur+9d
+  sbp:
+    crc: '0x5def'
+    length: 55
+    msg_type: '0x11'
+    payload: OPeLNQEAAAAAXCYFVAdAWXxEZAB0Vs347gA5MP//AAD7AAAAAgAQDgAAZAAKANAHAaqrrK2urw==
+    preamble: '0x55'
+    sender: '0xc043'
+
+- msg:
+    fields:
+      L:
+        f: 238
+        i: -120760716
+      P: 1149000000
+      P_std: 100
+      acceleration: 1
+      clock_drift: 10
+      clock_offset: 100
+      cn0: 0
+      corr_spacing: 2000
+      doppler: 251
+      doppler_std: 2
+      lock: 12345
+      misc_flags: 175
+      nav_flags: 173
+      pset_flags: 174
+      recv_time: 5193334392
+      sid:
+        code: 0
+        reserved: 0
+        sat: 65535
+      sync_flags: 170
+      tot:
+        tow: 86400000
+        wn: 1876
+      tow_flags: 171
+      track_flags: 172
+      uptime: 3600
+    module: sbp.tracking
+    name: MsgTrackingStateDetailed
+  msg_type: '0x11'
+  raw_json: '{"track_flags": 172, "doppler": 251, "clock_offset": 100, "msg_type":
+    17, "lock": 12345, "nav_flags": 173, "P_std": 100, "L": {"i": -120760716, "f":
+    238}, "pset_flags": 174, "P": 1149000000, "misc_flags": 175, "preamble": 85, "payload":
+    "eP6LNQEAAAAAXCYFVAdAWXxEZAB0Vs347gA5MP//AAD7AAAAAgAQDgAAZAAKANAHAaqrrK2urw==",
+    "recv_time": 5193334392, "acceleration": 1, "uptime": 3600, "sender": 49219, "cn0":
+    0, "doppler_std": 2, "tow_flags": 171, "tot": {"wn": 1876, "tow": 86400000}, "crc":
+    48733, "length": 55, "clock_drift": 10, "sid": {"code": 0, "reserved": 0, "sat":
+    65535}, "sync_flags": 170, "corr_spacing": 2000}'
+  raw_packet: VREAQ8A3eP6LNQEAAAAAXCYFVAdAWXxEZAB0Vs347gA5MP//AAD7AAAAAgAQDgAAZAAKANAHAaqrrK2ur12+
+  sbp:
+    crc: '0xbe5d'
+    length: 55
+    msg_type: '0x11'
+    payload: eP6LNQEAAAAAXCYFVAdAWXxEZAB0Vs347gA5MP//AAD7AAAAAgAQDgAAZAAKANAHAaqrrK2urw==
+    preamble: '0x55'
+    sender: '0xc043'
+
+- msg:
+    fields:
+      L:
+        f: 238
+        i: -120760716
+      P: 1149000000
+      P_std: 100
+      acceleration: 1
+      clock_drift: 10
+      clock_offset: 100
+      cn0: 0
+      corr_spacing: 2000
+      doppler: 251
+      doppler_std: 2
+      lock: 12345
+      misc_flags: 175
+      nav_flags: 173
+      pset_flags: 174
+      recv_time: 5193336270
+      sid:
+        code: 0
+        reserved: 0
+        sat: 65535
+      sync_flags: 170
+      tot:
+        tow: 86400000
+        wn: 1876
+      tow_flags: 171
+      track_flags: 172
+      uptime: 3600
+    module: sbp.tracking
+    name: MsgTrackingStateDetailed
+  msg_type: '0x11'
+  raw_json: '{"track_flags": 172, "doppler": 251, "clock_offset": 100, "msg_type":
+    17, "lock": 12345, "nav_flags": 173, "P_std": 100, "L": {"i": -120760716, "f":
+    238}, "pset_flags": 174, "P": 1149000000, "misc_flags": 175, "preamble": 85, "payload":
+    "zgWMNQEAAAAAXCYFVAdAWXxEZAB0Vs347gA5MP//AAD7AAAAAgAQDgAAZAAKANAHAaqrrK2urw==",
+    "recv_time": 5193336270, "acceleration": 1, "uptime": 3600, "sender": 49219, "cn0":
+    0, "doppler_std": 2, "tow_flags": 171, "tot": {"wn": 1876, "tow": 86400000}, "crc":
+    64417, "length": 55, "clock_drift": 10, "sid": {"code": 0, "reserved": 0, "sat":
+    65535}, "sync_flags": 170, "corr_spacing": 2000}'
+  raw_packet: VREAQ8A3zgWMNQEAAAAAXCYFVAdAWXxEZAB0Vs347gA5MP//AAD7AAAAAgAQDgAAZAAKANAHAaqrrK2ur6H7
+  sbp:
+    crc: '0xfba1'
+    length: 55
+    msg_type: '0x11'
+    payload: zgWMNQEAAAAAXCYFVAdAWXxEZAB0Vs347gA5MP//AAD7AAAAAgAQDgAAZAAKANAHAaqrrK2urw==
+    preamble: '0x55'
+    sender: '0xc043'
+version: null


### PR DESCRIPTION
All messages are round-tripped through construction and decoding, even if there aren't any test yaml files for them.
