### PR TITLE
Strip Obs from GPSTime - add it to the collisions list for C

### DIFF
--- a/generator/sbpg/targets/c.py
+++ b/generator/sbpg/targets/c.py
@@ -40,7 +40,7 @@ import re
 CONSTRUCT_CODE = set(['u8', 'u16', 'u32', 'u64', 's8', 's16', 's32',
                       's64', 'float', 'double'])
 
-COLLISIONS = set(['GnssSignal'])
+COLLISIONS = set(['GnssSignal', 'GPSTime'])
 
 def convert(value):
   """Converts to a C language appropriate identifier format.

--- a/generator/sbpg/targets/javascript.py
+++ b/generator/sbpg/targets/javascript.py
@@ -190,7 +190,7 @@ def render_source(output_dir, package_spec, jenv=JENV):
   destination_filename = "%s/%s.js" % (directory, name)
   py_template = jenv.get_template(TEMPLATE_NAME)
   module_path = ".".join(package_spec.identifier.split(".")[1:-1])
-  includeMap = {'gnss': ['GnssSignal', 'ObsGPSTime', 'CarrierPhase'] }
+  includeMap = {'gnss': ['GnssSignal', 'GPSTime', 'CarrierPhase'] }
   includes = [".".join(i.split(".")[:-1]) for i in package_spec.includes]
   includes = [(i, includeMap.get(i)) for i in includes if i != "types"]
   with open(destination_filename, 'w') as f:

--- a/spec/yaml/swiftnav/sbp/gnss.yaml
+++ b/spec/yaml/swiftnav/sbp/gnss.yaml
@@ -31,7 +31,7 @@ definitions:
             type: u8
             desc: Reserved
 
- - ObsGPSTime:
+ - GPSTime:
     short_desc: Millisecond-accurate GPS time
     desc: |
       A wire-appropriate GPS time, defined as the number of

--- a/spec/yaml/swiftnav/sbp/observation.yaml
+++ b/spec/yaml/swiftnav/sbp/observation.yaml
@@ -23,7 +23,7 @@ definitions:
     desc: Header of a GPS observation message.
     fields:
         - t:
-            type: ObsGPSTime
+            type: GPSTime
             desc: GPS time of this observation
         - n_obs:
             type: u8
@@ -140,7 +140,7 @@ definitions:
             type: GnssSignal
             desc: GNSS signal identifier
         - toe:
-            type: ObsGPSTime
+            type: GPSTime
             desc: Time of Ephemerides
         - ura:
             type: double
@@ -250,7 +250,7 @@ definitions:
           units: s/s^2
           desc: Polynomial clock correction coefficient (rate of clock drift)
       - toc:
-          type: ObsGPSTime
+          type: GPSTime
           desc: Clock reference
       - iode:
           type: u8
@@ -922,7 +922,7 @@ definitions:
       Please see ICD-GPS-200 (Chapter 20.3.3.5.1.7) for more details.
     fields:
       - t_nmct:
-          type: ObsGPSTime
+          type: GPSTime
           desc: Navigation Message Correction Table Valitidy Time
       - a0:
           type: double
@@ -956,7 +956,7 @@ definitions:
       Please see ICD-GPS-200 (Chapter 20.3.3.5.1.4) for more details.
     fields:
       - t_nmct:
-          type: ObsGPSTime
+          type: GPSTime
           desc: Navigation Message Correction Table Valitidy Time
       - l2c_mask:
           type: u32
@@ -968,7 +968,7 @@ definitions:
     desc: Please see ICD-GPS-200 (30.3.3.3.1.1) for more details.
     fields:
       - t_op:
-          type: ObsGPSTime
+          type: GPSTime
           desc: Data Predict Time of Week
       - prn:
           type: u8


### PR DESCRIPTION
Let's strip the Obs prefix from GPSTime - and then add it to the collisions list for C so that it becomes `sbp_gps_time_t` and doesn't conflict with `sbp_gnss_signal_t`.
